### PR TITLE
More CleanObject entries and (re)fix for planbuild terrain

### DIFF
--- a/InfinityHammer/Helper.cs
+++ b/InfinityHammer/Helper.cs
@@ -186,6 +186,10 @@ public static class HammerHelper
     DestroyComponents<DungeonGenerator>(obj);
     DestroyComponents<MusicLocation>(obj);
     DisableComponents<Fish>(obj);
+    DestroyComponents<Ragdoll>(obj);
+    DestroyComponents<LocationProxy>(obj);
+    DestroyComponents<MapTable>(obj);
+    DestroyComponents<ArcheryTarget>(obj);
 
     // Could be disables but destroying maybe better for performance.
     DestroyComponents<FootStep>(obj);
@@ -205,8 +209,11 @@ public static class HammerHelper
     DestroyComponents<StaticPhysics>(obj);
     DestroyComponents<Tameable>(obj);
     DestroyComponents<Catapult>(obj);
+
+    // Can destroy the prefab and break selection data
     DestroyComponents<TimedDestruction>(obj);
     DestroyComponents<Vine>(obj);
+    DestroyComponents<Plant>(obj);
 
     // Many things rely on Character so better just undo the Awake.
     var c = obj.GetComponent<Character>();

--- a/InfinityHammer/commands/blueprint/HammerBlueprint.cs
+++ b/InfinityHammer/commands/blueprint/HammerBlueprint.cs
@@ -112,6 +112,7 @@ public class HammerBlueprintCommand
     var terrainPaint = false;
     TerrainData? terrainData = null;
     var terrainRowIndex = 0;
+    var planbuildTerrain = false;
 
     foreach (var row in rows)
     {
@@ -140,6 +141,7 @@ public class HammerBlueprintCommand
           terrain = true;
           terrainHeight = true;
           terrainPaint = false;
+          planbuildTerrain = false;
           piece = false;
           terrainRowIndex = 0;
         }
@@ -148,6 +150,7 @@ public class HammerBlueprintCommand
       {
         terrainHeight = false;
         terrainPaint = true;
+        planbuildTerrain = false;
         terrainRowIndex = 0;
       }
       else if (row.StartsWith("#snappoints", StringComparison.OrdinalIgnoreCase))
@@ -156,6 +159,7 @@ public class HammerBlueprintCommand
         terrain = false;
         terrainHeight = false;
         terrainPaint = false;
+        planbuildTerrain = false;
       }
       else if (row.StartsWith("#terrain", StringComparison.OrdinalIgnoreCase))
       {
@@ -164,6 +168,7 @@ public class HammerBlueprintCommand
         terrain = false;
         terrainHeight = false;
         terrainPaint = false;
+        planbuildTerrain = true;
       }
       else if (row.StartsWith("#pieces", StringComparison.OrdinalIgnoreCase))
       {
@@ -171,6 +176,7 @@ public class HammerBlueprintCommand
         terrain = false;
         terrainHeight = false;
         terrainPaint = false;
+        planbuildTerrain = false;
       }
       else if (row.StartsWith("#", StringComparison.Ordinal))
         continue;
@@ -183,6 +189,10 @@ public class HammerBlueprintCommand
         else if (terrainPaint)
           ParseTerrainPaintRow(terrainData, row, terrainRowIndex);
         terrainRowIndex++;
+      }
+      else if (planbuildTerrain)
+      {
+        continue;
       }
       else if (!terrain)
         bp.SnapPoints.Add(GetPlanBuildSnapPoint(row));


### PR DESCRIPTION
Added more components to  be removed for ghost pieces, that may cause error/warnings or make prefabs disappear.

And fixed the fix for ignoring planbuild terrain, which was doing nothing at all (sorry)