### PR TITLE
Add deterministic terrain snapshot blueprints

### DIFF
--- a/InfinityHammer/Blueprint.cs
+++ b/InfinityHammer/Blueprint.cs
@@ -55,9 +55,11 @@ public class Blueprint
     foreach (var obj in Objects)
       obj.Pos -= center;
     SnapPoints = SnapPoints.Select(p => p - center).ToList();
+    // Terrain rows stay in their saved reference frame, so translate the new
+    // blueprint root into that frame instead of rotating the rows.
     if (TerrainHeight != null)
     {
-      TerrainHeight.CenterPosition -= center;
+      TerrainHeight.CenterPosition -= TerrainHeight.CenterRotation * center;
       for (int x = 0; x < TerrainHeight.Width; x++)
       {
         for (int z = 0; z < TerrainHeight.Height; z++)
@@ -68,7 +70,7 @@ public class Blueprint
       }
     }
     if (TerrainPaint != null)
-      TerrainPaint.CenterPosition -= center;
+      TerrainPaint.CenterPosition -= TerrainPaint.CenterRotation * center;
     if (rot != Quaternion.identity)
     {
       foreach (var obj in Objects)
@@ -79,14 +81,13 @@ public class Blueprint
       SnapPoints = SnapPoints.Select(p => rot * p).ToList();
       if (TerrainHeight != null)
       {
-        TerrainHeight.CenterPosition = rot * TerrainHeight.CenterPosition;
-        var terrainRotation = rot * TerrainHeight.CenterRotation;
+        // Piece positions use rot, while the terrain reference uses its inverse.
+        var terrainRotation = TerrainHeight.CenterRotation * Quaternion.Inverse(rot);
         TerrainHeight.CenterRotation = Quaternion.Euler(0f, terrainRotation.eulerAngles.y, 0f);
       }
       if (TerrainPaint != null)
       {
-        TerrainPaint.CenterPosition = rot * TerrainPaint.CenterPosition;
-        var paintTerrainRotation = rot * TerrainPaint.CenterRotation;
+        var paintTerrainRotation = TerrainPaint.CenterRotation * Quaternion.Inverse(rot);
         TerrainPaint.CenterRotation = Quaternion.Euler(0f, paintTerrainRotation.eulerAngles.y, 0f);
       }
     }

--- a/InfinityHammer/commands/HammerZoop.cs
+++ b/InfinityHammer/commands/HammerZoop.cs
@@ -72,15 +72,20 @@ public partial class ObjectSelection : BaseSelection
   private int ZoopsY = 0;
   private int ZoopsZ = 0;
   private Vector3 ZoopOffset = new();
+  private Vector3 ZoopOrigin = new();
   private readonly Dictionary<Vector3Int, GameObject> Zoops = [];
   public void ZoopReset()
   {
-    if (Objects.Count > 1)
-      ToSingle();
+    foreach (var zoop in Zoops.Values.ToList())
+    {
+      if (zoop)
+        RemoveObject(zoop);
+    }
     ZoopsX = 0;
     ZoopsY = 0;
     ZoopsZ = 0;
     ZoopOffset = new();
+    ZoopOrigin = new();
     Zoops.Clear();
     ZoopPostprocess();
   }
@@ -109,8 +114,11 @@ public partial class ObjectSelection : BaseSelection
   }
   private void AddChildSub(Vector3Int index)
   {
-    var pos = GetOffset(index);
-    Zoops[index] = AddObject(BasePrefab.GetComponent<ZNetView>(), pos);
+    var basePrefab = BasePrefab;
+    if (Zoops.Count == 0)
+      ZoopOrigin = UsesSelectionRoot ? basePrefab.transform.localPosition : Vector3.zero;
+    var pos = ZoopOrigin + GetOffset(index);
+    Zoops[index] = AddObject(basePrefab.GetComponent<ZNetView>(), pos);
     if (Configuration.ZoopMagic == ZoopMagicMode.Mild) Center();
     if (Configuration.ZoopMagic == ZoopMagicMode.Wild) CenterOnRandomChild();
   }
@@ -162,7 +170,17 @@ public partial class ObjectSelection : BaseSelection
     offset.z *= index.z;
     return offset;
   }
-  private GameObject BasePrefab => Zoops.Count > 0 ? Zoops.First().Value : SelectedPrefab;
+  private GameObject BasePrefab
+  {
+    get
+    {
+      if (Zoops.Count > 0)
+        return Zoops.First().Value;
+      if (UsesSelectionRoot && Objects.Count == 1)
+        return Snapping.GetChildren(SelectedPrefab).FirstOrDefault() ?? SelectedPrefab;
+      return SelectedPrefab;
+    }
+  }
   private void UpdateOffsetX(string offset)
   {
     var size = HammerHelper.ParseSize(BasePrefab, offset);

--- a/InfinityHammer/commands/blueprint/HammerBlueprint.cs
+++ b/InfinityHammer/commands/blueprint/HammerBlueprint.cs
@@ -11,6 +11,15 @@ namespace InfinityHammer;
 #pragma warning disable IDE0046
 public class HammerBlueprintCommand : TextReceiver
 {
+  private enum PlanBuildSection
+  {
+    Skip,
+    Pieces,
+    SnapPoints,
+    TerrainHeight,
+    TerrainPaint
+  }
+
   private static void PrintSelected(Terminal terminal, string name)
   {
     if (Configuration.DisableSelectMessages) return;
@@ -104,22 +113,33 @@ public class HammerBlueprintCommand : TextReceiver
     }
     return bp;
   }
-  private static Blueprint GetPlanBuild(Blueprint bp, string[] rows, bool loadData)
+  internal static Blueprint GetPlanBuild(Blueprint bp, string[] rows, bool loadData)
   {
-    var piece = true;
-    var parseTerrainHeight = false;
-    var parseTerrainPaint = false;
+    var section = PlanBuildSection.Pieces;
     TerrainHeight? terrainHeightData = null;
     TerrainPaint? terrainPaintData = null;
     var terrainRowIndex = 0;
-    var planbuildTerrain = false;
 
     foreach (var row in rows)
     {
+      var isHeader = row.StartsWith("#", StringComparison.Ordinal);
+      if (isHeader)
+      {
+        terrainRowIndex = 0;
+        // Metadata and comments can appear between legacy piece rows. Terrain
+        // payloads, however, always end at the next header.
+        if (section is PlanBuildSection.TerrainHeight or PlanBuildSection.TerrainPaint)
+          section = PlanBuildSection.Skip;
+      }
+
       if (row.StartsWith("#name:", StringComparison.OrdinalIgnoreCase))
         bp.Name = row.Split(':')[1];
+      else if (row.StartsWith("#creator:", StringComparison.OrdinalIgnoreCase))
+        bp.Creator = row.Split(':')[1];
       else if (row.StartsWith("#description:", StringComparison.OrdinalIgnoreCase))
         bp.Description = row.Split(':')[1];
+      else if (row.StartsWith("#category:", StringComparison.OrdinalIgnoreCase))
+        bp.Category = row.Split(':')[1];
       else if (row.StartsWith("#center:", StringComparison.OrdinalIgnoreCase))
         bp.CenterPiece = row.Split(':')[1];
       else if (row.StartsWith("#coordinates:", StringComparison.OrdinalIgnoreCase))
@@ -132,6 +152,8 @@ public class HammerBlueprintCommand : TextReceiver
       }
       else if (row.StartsWith("#terrainheight:", StringComparison.OrdinalIgnoreCase))
       {
+        // A malformed channel header must not inherit the preceding section.
+        section = PlanBuildSection.Skip;
         var parts = row.Split(':')[1].Split(';');
         if (parts.Length >= 3)
         {
@@ -142,15 +164,13 @@ public class HammerBlueprintCommand : TextReceiver
             CenterRotation = Quaternion.Euler(0f, rotation, 0f),
             DistanceBetweenNodes = InvariantFloat(parts, 2, 1.0f)
           };
-          piece = false;
-          parseTerrainHeight = true;
-          parseTerrainPaint = false;
-          planbuildTerrain = false;
-          terrainRowIndex = 0;
+          section = PlanBuildSection.TerrainHeight;
         }
       }
       else if (row.StartsWith("#terrainpaint:", StringComparison.OrdinalIgnoreCase))
       {
+        // A malformed channel header must not inherit the preceding section.
+        section = PlanBuildSection.Skip;
         var parts = row.Split(':')[1].Split(';');
         if (parts.Length >= 3)
         {
@@ -161,54 +181,42 @@ public class HammerBlueprintCommand : TextReceiver
             CenterRotation = Quaternion.Euler(0f, rotation, 0f),
             DistanceBetweenNodes = InvariantFloat(parts, 2, 1.0f)
           };
-          piece = false;
-          parseTerrainHeight = false;
-          parseTerrainPaint = true;
-          planbuildTerrain = false;
-          terrainRowIndex = 0;
+          section = PlanBuildSection.TerrainPaint;
         }
       }
-      else if (row.StartsWith("#terrain", StringComparison.OrdinalIgnoreCase))
-      {
-        piece = false;
-        parseTerrainHeight = false;
-        parseTerrainPaint = false;
-        planbuildTerrain = false;
-      }
       else if (row.StartsWith("#snappoints", StringComparison.OrdinalIgnoreCase))
-      {
-        piece = false;
-        parseTerrainHeight = false;
-        parseTerrainPaint = false;
-        planbuildTerrain = false;
-      }
+        section = PlanBuildSection.SnapPoints;
       else if (row.StartsWith("#pieces", StringComparison.OrdinalIgnoreCase))
+        section = PlanBuildSection.Pieces;
+      else if (isHeader)
       {
-        piece = true;
-        parseTerrainHeight = false;
-        parseTerrainPaint = false;
-        planbuildTerrain = false;
-      }
-      else if (row.StartsWith("#", StringComparison.Ordinal))
-        continue;
-      else if (piece)
-        bp.Objects.Add(GetPlanBuildObject(row, loadData));
-      else if (parseTerrainHeight && terrainHeightData != null)
-      {
-        ParseTerrainHeightRow(terrainHeightData, row, terrainRowIndex);
-        terrainRowIndex++;
-      }
-      else if (parseTerrainPaint && terrainPaintData != null)
-      {
-        ParseTerrainPaintRow(terrainPaintData, row, terrainRowIndex);
-        terrainRowIndex++;
-      }
-      else if (planbuildTerrain)
-      {
+        // Keep ordinary comments compatible with headerless piece lists, but
+        // skip payload following unknown section headers.
+        var isComment = row.Length == 1 || char.IsWhiteSpace(row[1]);
+        if (!isComment)
+          section = PlanBuildSection.Skip;
         continue;
       }
-      else if (!parseTerrainHeight && !parseTerrainPaint)
-        bp.SnapPoints.Add(GetPlanBuildSnapPoint(row));
+      else
+      {
+        switch (section)
+        {
+          case PlanBuildSection.Pieces:
+            bp.Objects.Add(GetPlanBuildObject(row, loadData));
+            break;
+          case PlanBuildSection.SnapPoints:
+            bp.SnapPoints.Add(GetPlanBuildSnapPoint(row));
+            break;
+          case PlanBuildSection.TerrainHeight when terrainHeightData != null:
+            ParseTerrainHeightRow(terrainHeightData, row, terrainRowIndex);
+            terrainRowIndex++;
+            break;
+          case PlanBuildSection.TerrainPaint when terrainPaintData != null:
+            ParseTerrainPaintRow(terrainPaintData, row, terrainRowIndex);
+            terrainRowIndex++;
+            break;
+        }
+      }
     }
 
     bp.TerrainHeight = terrainHeightData;

--- a/InfinityHammer/commands/blueprint/HammerSave.cs
+++ b/InfinityHammer/commands/blueprint/HammerSave.cs
@@ -57,7 +57,7 @@ public class HammerSaveCommand : TextReceiver
       bp.TerrainPaint = selection.TerrainPaintInfo.Clone();
     var objects = Snapping.GetChildren(obj);
     Dictionary<string, string> pars = [];
-    if (selection.Objects.Count() == 1)
+    if (!selection.UsesSelectionRoot)
     {
       AddSingleObject(bp, pars, obj, saveData);
       // Snap points are sort of useful for single objects.
@@ -237,7 +237,10 @@ public class HammerSaveCommand : TextReceiver
       Directory.CreateDirectory(Path.GetDirectoryName(path));
       File.WriteAllLines(path, lines);
       args.Context.AddString($"Blueprint saved to {path.Replace("\\", "\\\\")} (pos: {HammerHelper.PrintXZY(bp.Coordinates)} rot: {HammerHelper.PrintYXZ(bp.Rotation)}).");
-      Selection.CreateGhost(new ObjectSelection(args.Context, bp, Vector3.one));
+      // Use the serialized representation so immediate placement and a later reload
+      // have identical terrain anchors, dimensions and numeric precision.
+      var savedBlueprint = HammerBlueprintCommand.GetPlanBuild(new() { Name = bp.Name }, lines, true);
+      Selection.CreateGhost(new ObjectSelection(args.Context, savedBlueprint, Vector3.one));
     }
     Pars = null;
     Args = null;

--- a/InfinityHammer/commands/hammer/Hammer.cs
+++ b/InfinityHammer/commands/hammer/Hammer.cs
@@ -211,7 +211,9 @@ public class HammerSelect
         var paintNodeSpacing = Configuration.BlueprintPaintNodeSpacing;
 
         Vector3 centerPos = views[0].transform.position;
-        Quaternion centerRot = views[0].transform.rotation;
+        // Multiple selections use an unrotated wrapper whose origin is the first object.
+        // Keep terrain in the same reference frame as that placement root.
+        Quaternion centerRot = views.Length == 1 ? views[0].transform.rotation : Quaternion.identity;
         Vector3 searchPos = centerPos;
         if (pars.Radius != null || (pars.Width != null && pars.Depth != null))
           searchPos = pars.Position;

--- a/InfinityHammer/selection/ObjectSelection.cs
+++ b/InfinityHammer/selection/ObjectSelection.cs
@@ -21,6 +21,7 @@ public partial class ObjectSelection : BaseSelection
   public List<SelectedObject> Objects = [];
   public TerrainHeight? TerrainHeightInfo;
   public TerrainPaint? TerrainPaintInfo;
+  public bool UsesSelectionRoot { get; private set; }
   private string SelectionBaseDescription = "";
   public override void Destroy()
   {
@@ -37,6 +38,8 @@ public partial class ObjectSelection : BaseSelection
     TerrainHeightInfo = terrainHeightInfo;
     TerrainPaintInfo = terrainPaintInfo;
   }
+
+  private bool CanCollapseToSingleObject => Objects.Count == 1 && TerrainHeightInfo == null && TerrainPaintInfo == null;
 
   public ObjectSelection(ZNetView view, bool singleUse, Vector3? scale, DataEntry? extraData, TerrainHeight? terrainHeightInfo = null, TerrainPaint? terrainPaintInfo = null)
   {
@@ -86,6 +89,7 @@ public partial class ObjectSelection : BaseSelection
   {
     Wrapper = new GameObject();
     Wrapper.SetActive(false);
+    UsesSelectionRoot = true;
 
     SingleUse = singleUse;
     SelectedPrefab = new GameObject();
@@ -118,6 +122,7 @@ public partial class ObjectSelection : BaseSelection
   {
     Wrapper = new GameObject();
     Wrapper.SetActive(false);
+    UsesSelectionRoot = true;
 
     SelectedPrefab = new GameObject();
     SelectedPrefab.transform.SetParent(Wrapper.transform);
@@ -154,8 +159,10 @@ public partial class ObjectSelection : BaseSelection
         HammerHelper.Message(terminal, $"Warning: {e.Message}");
       }
     }
-    // Might be good to have a proper loading for single item blueprints, but this works for now.
-    if (Objects.Count == 1)
+    SetTerrainState(bp.TerrainHeight?.Clone(), bp.TerrainPaint?.Clone());
+    // Terrain is placed relative to the blueprint root, even when only one
+    // object survives prefab filtering.
+    if (CanCollapseToSingleObject)
       ToSingle();
 
     // Snapping not needed when the user is using a specific center point.
@@ -170,9 +177,6 @@ public partial class ObjectSelection : BaseSelection
     piece.m_clipEverything = Snapping.CountSnapPoints(SelectedPrefab) == 0;
     Scaling.Set(SelectedPrefab);
 
-    var terrainHeightInfo = bp.TerrainHeight?.Clone();
-    var terrainPaintInfo = bp.TerrainPaint?.Clone();
-    SetTerrainState(terrainHeightInfo, terrainPaintInfo);
     UpdateSelectionDescription();
   }
 
@@ -237,7 +241,7 @@ public partial class ObjectSelection : BaseSelection
   }
   public void Postprocess()
   {
-    if (Objects.Count == 1)
+    if (!UsesSelectionRoot)
     {
       if (Snapping.CountSnapPoints(SelectedPrefab) == 0)
         Snapping.CreateSnapPoint(SelectedPrefab, Vector3.zero, "Center");
@@ -414,7 +418,7 @@ public partial class ObjectSelection : BaseSelection
   public override GameObject GetPrefab(GameObject obj)
   {
     UndoHelper.BeginSubAction();
-    if (Objects.Count == 1)
+    if (!UsesSelectionRoot)
     {
       var name = Utils.GetPrefabName(obj);
       var tr = HammerHelper.GetPlacementGhost().transform;
@@ -432,7 +436,7 @@ public partial class ObjectSelection : BaseSelection
   }
   public override void AfterPlace(GameObject obj)
   {
-    if (Objects.Count == 1)
+    if (!UsesSelectionRoot)
     {
       var view = obj.GetComponent<ZNetView>();
       // Hoe adds pieces too.
@@ -487,7 +491,7 @@ public partial class ObjectSelection : BaseSelection
             });
 
             var altitude = nearestHeight.Value + placementPosition.y;
-            compiler.m_levelDelta[index] += altitude - compiler.m_hmap.m_heights[index];
+            compiler.m_levelDelta[index] += compiler.m_smoothDelta[index] + altitude - compiler.m_hmap.m_heights[index];
             compiler.m_smoothDelta[index] = 0f;
             compiler.m_modifiedHeight[index] = compiler.m_levelDelta[index] != 0f;
 
@@ -501,7 +505,10 @@ public partial class ObjectSelection : BaseSelection
           }
 
           var nearestPaint = TerrainPaintInfo?.FindNearest(nodePos, placementPosition, paintRotation);
-          if (nearestPaint != null && index < compiler.m_paintMask.Length && nearestPaint != compiler.m_paintMask[index])
+          // Snapshot paint is an exact final value. An unmodified compiler cell
+          // must still be written so the destination's base biome paint cannot leak through.
+          if (nearestPaint != null && index < compiler.m_paintMask.Length &&
+              (!compiler.m_modifiedPaint[index] || nearestPaint != compiler.m_paintMask[index]))
           {
             beforeTerrain.Paints.Add(new()
             {
@@ -559,6 +566,7 @@ public partial class ObjectSelection : BaseSelection
   }
   private void HandleMultiple(GameObject ghost)
   {
+    ApplyTerrainChanges(ghost.transform.position, ghost.transform.rotation);
     var children = Snapping.GetChildren(ghost);
     for (var i = 0; i < children.Count; i++)
     {
@@ -573,14 +581,12 @@ public partial class ObjectSelection : BaseSelection
         var childObj = UnityEngine.Object.Instantiate(prefab, ghostChild.transform.position, ghostChild.transform.rotation);
         PostProcessPlaced(childObj);
       }
-      if (i == 0)
-        ApplyTerrainChanges(ghostChild.transform.position, ghostChild.transform.rotation);
     }
   }
 
   public GameObject AddObject(ZNetView view, Vector3 pos)
   {
-    if (Objects.Count == 1)
+    if (!UsesSelectionRoot)
       ToMulti();
     var obj = HammerHelper.ChildInstantiate(view, SelectedPrefab);
     obj.transform.rotation = view.transform.rotation;
@@ -605,6 +611,7 @@ public partial class ObjectSelection : BaseSelection
       if (prefab && !prefab.GetComponent<Piece>())
         UnityEngine.Object.Destroy(piece);
     }
+    UsesSelectionRoot = true;
   }
   public void RemoveObject(GameObject obj)
   {
@@ -615,7 +622,7 @@ public partial class ObjectSelection : BaseSelection
     obj.transform.SetParent(null);
     UnityEngine.Object.Destroy(obj);
     Objects.RemoveAt(Objects.Count - 1);
-    if (Objects.Count == 1)
+    if (CanCollapseToSingleObject)
       ToSingle();
     else if (Configuration.Snapping != SnappingMode.Off)
       Snapping.RegenerateSnapPoints(SelectedPrefab);
@@ -631,6 +638,7 @@ public partial class ObjectSelection : BaseSelection
     UnityEngine.Object.Destroy(SelectedPrefab);
     SelectedPrefab = obj;
     Objects = [.. Objects.Take(1)];
+    UsesSelectionRoot = false;
   }
   public override void Activate()
   {

--- a/InfinityHammer/service/Terrain.cs
+++ b/InfinityHammer/service/Terrain.cs
@@ -11,28 +11,17 @@ public abstract class TerrainChannelData<TValue> where TValue : struct
 {
   public Vector3 CenterPosition;
   public Quaternion CenterRotation = Quaternion.identity;
-  public Vector3? FirstNodeAnchor;
   public float DistanceBetweenNodes = 1.0f;
-  public float? CaptureRadius;
   public int Width = 0;
   public int Height = 0;
 
-  public float GetRadius() => CaptureRadius ??= GetRequiredRadius();
+  public float GetRadius() => GetRequiredRadius();
 
   protected void InitializeReference(int width, int height, Vector3 centerPos)
   {
     Width = width;
     Height = height;
     CenterPosition = centerPos;
-    FirstNodeAnchor = null;
-  }
-
-  protected void InitializeReference(int width, int height, Vector3 centerPos, Vector3 firstNodeAnchor)
-  {
-    Width = width;
-    Height = height;
-    CenterPosition = centerPos;
-    FirstNodeAnchor = firstNodeAnchor;
   }
 
   private float GetRequiredRadius()
@@ -43,21 +32,24 @@ public abstract class TerrainChannelData<TValue> where TValue : struct
     var spacing = Mathf.Max(0.001f, DistanceBetweenNodes);
     var halfOffsetX = (Width - 1) * spacing * 0.5f;
     var halfOffsetZ = (Height - 1) * spacing * 0.5f;
-    var corners = new[]
+    var firstNode = CenterPosition - new Vector3(halfOffsetX, 0f, halfOffsetZ);
+    var radius = 0f;
+    for (var x = 0; x < Width; x++)
     {
-      CenterPosition + CenterRotation * new Vector3(-halfOffsetX, 0f, -halfOffsetZ),
-      CenterPosition + CenterRotation * new Vector3(halfOffsetX, 0f, -halfOffsetZ),
-      CenterPosition + CenterRotation * new Vector3(-halfOffsetX, 0f, halfOffsetZ),
-      CenterPosition + CenterRotation * new Vector3(halfOffsetX, 0f, halfOffsetZ)
-    };
-    return corners.Max(Utils.LengthXZ);
+      for (var z = 0; z < Height; z++)
+      {
+        if (!Get(x, z).HasValue)
+          continue;
+        var node = firstNode + new Vector3(x * spacing, 0f, z * spacing);
+        radius = Mathf.Max(radius, Utils.LengthXZ(node));
+      }
+    }
+    return radius;
   }
 
   public void SetReference(Vector3 center, Quaternion rotation)
   {
     CenterPosition -= center;
-    if (FirstNodeAnchor.HasValue)
-      FirstNodeAnchor = FirstNodeAnchor.Value - center;
     CenterRotation = GetYawRotation(rotation);
     OnSetReference(center);
   }
@@ -75,16 +67,8 @@ public abstract class TerrainChannelData<TValue> where TValue : struct
   {
   }
 
-  protected Vector3 GetCenterAnchor()
-  {
-    return CenterPosition;
-  }
-
   protected Vector3 GetFirstNodeAnchor()
   {
-    if (FirstNodeAnchor.HasValue)
-      return FirstNodeAnchor.Value;
-
     var spacing = Mathf.Max(0.001f, DistanceBetweenNodes);
     var halfOffsetX = (Width - 1) * spacing * 0.5f;
     var halfOffsetZ = (Height - 1) * spacing * 0.5f;
@@ -121,12 +105,6 @@ public class TerrainHeight : TerrainChannelData<float>
   public void InitializeGrid(int width, int height, Vector3 centerPosition)
   {
     InitializeReference(width, height, centerPosition);
-    Heights = new float?[width, height];
-  }
-
-  public void InitializeGrid(int width, int height, Vector3 centerPosition, Vector3 firstNodeAnchor)
-  {
-    InitializeReference(width, height, centerPosition, firstNodeAnchor);
     Heights = new float?[width, height];
   }
 
@@ -170,9 +148,7 @@ public class TerrainHeight : TerrainChannelData<float>
     {
       CenterPosition = CenterPosition,
       CenterRotation = CenterRotation,
-      FirstNodeAnchor = FirstNodeAnchor,
       DistanceBetweenNodes = DistanceBetweenNodes,
-      CaptureRadius = CaptureRadius,
       Width = Width,
       Height = Height,
       Heights = new float?[Width, Height]
@@ -197,12 +173,6 @@ public class TerrainPaint : TerrainChannelData<Color>
   public void InitializeGrid(int width, int height, Vector3 centerPosition)
   {
     InitializeReference(width, height, centerPosition);
-    Paints = new Color?[width, height];
-  }
-
-  public void InitializeGrid(int width, int height, Vector3 centerPosition, Vector3 firstNodeAnchor)
-  {
-    InitializeReference(width, height, centerPosition, firstNodeAnchor);
     Paints = new Color?[width, height];
   }
 
@@ -234,9 +204,7 @@ public class TerrainPaint : TerrainChannelData<Color>
     {
       CenterPosition = CenterPosition,
       CenterRotation = CenterRotation,
-      FirstNodeAnchor = FirstNodeAnchor,
       DistanceBetweenNodes = DistanceBetweenNodes,
-      CaptureRadius = CaptureRadius,
       Width = Width,
       Height = Height,
       Paints = new Color?[Width, Height]
@@ -259,7 +227,12 @@ public class TerrainInfo
 
   public static float ResolveRadius(TerrainHeight? height, TerrainPaint? paint)
   {
-    return Mathf.Max(height?.GetRadius() ?? 0f, paint?.GetRadius() ?? 0f);
+    var sampleRadius = Mathf.Max(height?.GetRadius() ?? 0f, paint?.GetRadius() ?? 0f);
+    // FindNearest rounds to the nearest snapshot node, so the affected area
+    // extends beyond the outer node centers. Include a conservative node/grid
+    // margin when finding compilers, recording undo and refreshing clutter.
+    var samplingMargin = Mathf.Max(1f, height?.DistanceBetweenNodes ?? 0f, paint?.DistanceBetweenNodes ?? 0f);
+    return sampleRadius + samplingMargin;
   }
 
   private static Vector3 VertexToWorld(Heightmap hmap, int x, int z)
@@ -277,7 +250,6 @@ public class TerrainInfo
   {
     var compilers = Terrain.GetCompilers(searchPos, new(radius.Max)).ToList();
     var data = MergeHeightmapsWithCircle(compilers, searchPos, radius, nodeSpacingOverride);
-    data.CaptureRadius = radius.Max;
     data.SetReference(centerPos, centerRot);
     return data;
   }
@@ -286,27 +258,22 @@ public class TerrainInfo
   {
     var compilers = Terrain.GetCompilers(searchPos, new(radius.Max)).ToList();
     var data = MergePaintmapsWithCircle(compilers, searchPos, radius, nodeSpacingOverride);
-    data.CaptureRadius = radius.Max;
     data.SetReference(centerPos, centerRot);
     return data;
   }
 
   public static TerrainHeight CollectTerrainHeightInRect(Vector3 centerPos, Quaternion centerRot, Vector3 searchPos, Range<float> width, Range<float> depth, float angle, float nodeSpacingOverride = 0f)
   {
-    var radius = Math.Max(width.Max, depth.Max);
-    var compilers = Terrain.GetCompilers(searchPos, new(radius)).ToList();
-    var data = MergeHeightmapsWithRect(compilers, centerPos, width, depth, angle, nodeSpacingOverride);
-    data.CaptureRadius = radius;
+    var compilers = Terrain.GetCompilers(searchPos, width, depth, angle).ToList();
+    var data = MergeHeightmapsWithRect(compilers, searchPos, width, depth, angle, nodeSpacingOverride);
     data.SetReference(centerPos, centerRot);
     return data;
   }
 
   public static TerrainPaint CollectTerrainPaintInRect(Vector3 centerPos, Quaternion centerRot, Vector3 searchPos, Range<float> width, Range<float> depth, float angle, float nodeSpacingOverride = 0f)
   {
-    var radius = Math.Max(width.Max, depth.Max);
-    var compilers = Terrain.GetCompilers(searchPos, new(radius)).ToList();
-    var data = MergePaintmapsWithRect(compilers, centerPos, width, depth, angle, nodeSpacingOverride);
-    data.CaptureRadius = radius;
+    var compilers = Terrain.GetCompilers(searchPos, width, depth, angle).ToList();
+    var data = MergePaintmapsWithRect(compilers, searchPos, width, depth, angle, nodeSpacingOverride);
     data.SetReference(centerPos, centerRot);
     return data;
   }
@@ -364,8 +331,7 @@ public class TerrainInfo
     mergedData.InitializeGrid(
       gridWidth,
       gridHeight,
-      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f),
-      new Vector3(minWorldX, 0f, minWorldZ)
+      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f)
     );
     mergedData.DistanceBetweenNodes = spacing;
 
@@ -440,8 +406,7 @@ public class TerrainInfo
     mergedData.InitializeGrid(
       gridWidth,
       gridHeight,
-      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f),
-      new Vector3(minWorldX, 0f, minWorldZ)
+      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f)
     );
     mergedData.DistanceBetweenNodes = spacing;
 
@@ -457,14 +422,12 @@ public class TerrainInfo
           if (!Helper.Within(radius, distance))
             continue;
 
-          var index = z * max + x;
-          if (index >= compiler.m_paintMask.Length)
-            continue;
-
           int gridX = Mathf.RoundToInt((nodePos.x - minWorldX) / spacing);
           int gridZ = Mathf.RoundToInt((nodePos.z - minWorldZ) / spacing);
           if (mergedData.Get(gridX, gridZ) == null)
-            mergedData.Set(gridX, gridZ, compiler.m_paintMask[index]);
+            // TerrainComp only stores meaningful paint for modified cells.
+            // Read the composed Heightmap so the snapshot contains final values.
+            mergedData.Set(gridX, gridZ, compiler.m_hmap.GetPaintMask(x, z));
         }
       }
     }
@@ -520,8 +483,7 @@ public class TerrainInfo
     mergedData.InitializeGrid(
       gridWidth,
       gridHeight,
-      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f),
-      new Vector3(minWorldX, 0f, minWorldZ)
+      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f)
     );
     mergedData.DistanceBetweenNodes = spacing;
 
@@ -604,8 +566,7 @@ public class TerrainInfo
     mergedData.InitializeGrid(
       gridWidth,
       gridHeight,
-      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f),
-      new Vector3(minWorldX, 0f, minWorldZ)
+      new Vector3(minWorldX + (gridWidth - 1) * spacing * 0.5f, 0f, minWorldZ + (gridHeight - 1) * spacing * 0.5f)
     );
     mergedData.DistanceBetweenNodes = spacing;
 
@@ -625,14 +586,11 @@ public class TerrainInfo
           if (!Helper.Within(width, depth, Mathf.Abs(dx), Mathf.Abs(dz)))
             continue;
 
-          var index = z * max + x;
-          if (index >= compiler.m_paintMask.Length)
-            continue;
-
           int gridX = Mathf.RoundToInt((nodePos.x - minWorldX) / spacing);
           int gridZ = Mathf.RoundToInt((nodePos.z - minWorldZ) / spacing);
           if (mergedData.Get(gridX, gridZ) == null)
-            mergedData.Set(gridX, gridZ, compiler.m_paintMask[index]);
+            // See the circular capture path above: snapshot composed paint.
+            mergedData.Set(gridX, gridZ, compiler.m_hmap.GetPaintMask(x, z));
         }
       }
     }

--- a/blueprints.md
+++ b/blueprints.md
@@ -40,6 +40,42 @@ The command has optional parameters. Their default values can be set in the conf
 
 Note: Infinity Hammer also stores the object data when creating blueprints. This can significantly increase the file size and cause incompatibility with future PlanBuild versions. If needed, disable "Save blueprint data" from the config.
 
+### Terrain snapshots
+
+Area selections can include the final terrain height and paint values. These are snapshots of the selected terrain nodes, not a list of terrain operations. Placing the blueprint applies the saved values once relative to the blueprint root, so the result doesn't depend on the order of the original terrain edits.
+
+Terrain is stored in two optional sections after `#Pieces`:
+
+```text
+#TerrainHeight:<center x,z,y>;<reference yaw>;<node spacing>
+<height or empty>;<height or empty>;...
+#TerrainPaint:<center x,z,y>;<reference yaw>;<node spacing>
+<r:g:b:a or empty>;<r:g:b:a or empty>;...
+```
+
+- Header vectors and all numbers use invariant decimal notation. The vector order is X, Z, Y.
+- The center is relative to the blueprint root. Height samples are relative to the root Y coordinate.
+- Each following line is one Z row and each semicolon-separated field is one X column. Every row in a section has the same number of columns.
+- Empty fields are outside the captured shape and must not modify terrain.
+- The first node is `center - ((columns - 1) * spacing / 2, 0, (rows - 1) * spacing / 2)`.
+- Reference yaw records the terrain capture reference. Placement uses the yaw difference between this value and the blueprint root yaw.
+- A section ends at the next line beginning with `#` or at the end of the file.
+- Consumers without terrain support must skip the section rows until that boundary instead of interpreting them as pieces or snap points.
+- These sections are an Infinity Hammer/Expand World Data extension. Current PlanBuild versions do not understand the snapshot rows, so terrain-enabled files must not be loaded directly in PlanBuild until it adds support for this contract.
+- Blueprint object scaling does not scale the terrain grid.
+
+When a blueprint is recentered, terrain rows keep their X/Z order. Given the selected center offset `T`, its inverse rotation `K` as applied to piece positions, terrain center `C` and reference yaw `R`, the terrain contract transforms as follows:
+
+```text
+C' = C - R * T
+R' = R * inverse(K)
+height' = height - T.y
+```
+
+Paint values and empty cells are unchanged.
+
+The "Save simpler blueprints" option only writes mandatory piece data and omits terrain sections.
+
 Following data is not copied:
 
 - Object scale (redundant because the blueprint has own fields or the scale).

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,37 @@
+# Test fixtures
+
+`fixtures/terrain-blueprint-contract.blueprint` is a minimal interoperability and manual regression fixture for terrain snapshots.
+
+It deliberately places the first piece at X = -2 while the terrain grid is centered at X = 1. This catches multi-piece placement code that incorrectly uses the first child instead of the blueprint root. The height and paint sections are both 3 columns by 2 rows and contain one empty cell, which consumers must leave unchanged.
+
+Manual round-trip check:
+
+1. Load and place the fixture at a known position and yaw.
+2. Confirm that the terrain grid is positioned from the blueprint root, not from the first floor piece.
+3. Save the active selection under a new name.
+4. Place it immediately, then reload the saved file and place it again at the same position and yaw on clean terrain.
+5. Compare the affected nodes. Both placements must use the same anchor, search radius, height values, and paint values.
+
+For paint, include both untouched biome paint and a clear-vegetation cell. Place the snapshot over different destination paint and confirm both cells are explicit final values; an unmodified `TerrainComp` cell must not leak destination paint into the result.
+
+## Rotated center regression
+
+`fixtures/terrain-rotated-center.blueprint` uses a center piece at `(2, 1, 0)` with yaw 90 degrees, while both terrain channels start at center `(5, 10, 7)` with reference yaw 30 degrees.
+
+After `Blueprint.Center("wood_floor")`:
+
+- The center piece must be at the origin with identity rotation.
+- The terrain center must be approximately `(3.268, 9, 8)` in X, Y, Z order.
+- The terrain reference yaw must be approximately 120 degrees.
+- Height rows must retain their order and become `10;11` and `12;13` after subtracting the root Y offset.
+- Paint rows must remain unchanged.
+
+Repeat placement at yaw 0, 90 and 180 degrees. The terrain must retain the same offset and orientation relative to both pieces.
+
+## Future section regression
+
+`fixtures/terrain-future-section.blueprint` puts valid-looking payload rows after unknown and malformed headers. A parser must:
+
+- Load exactly one piece (`wood_floor`), never `future_payload`.
+- Load a 2 by 2 height grid; `999` and `888` must not be appended to it.
+- Load the following 2 by 2 paint grid normally.

--- a/tests/fixtures/terrain-blueprint-contract.blueprint
+++ b/tests/fixtures/terrain-blueprint-contract.blueprint
@@ -1,0 +1,17 @@
+#Name:Terrain blueprint contract fixture
+#Creator:Infinity Hammer
+#Description:Two pieces with a terrain grid whose origin differs from the first piece
+#Category:InfinityHammer
+#Center:
+#Coordinates:0,0,0
+#Rotation:0,0,0
+#SnapPoints
+#Pieces
+wood_floor;;-2;0;0;0;0;0;1;;1;1;1;
+wood_floor;;2;0;0;0;0;0;1;;1;1;1;
+#TerrainHeight:1,0,0;0;1
+1;;3
+4;5;6
+#TerrainPaint:1,0,0;0;1
+1:0:0:1;;0:1:0:1
+0:0:1:1;1:1:1:1;0:0:0:1

--- a/tests/fixtures/terrain-future-section.blueprint
+++ b/tests/fixtures/terrain-future-section.blueprint
@@ -1,0 +1,22 @@
+#Name:Future terrain section fixture
+#Creator:Infinity Hammer
+#Description:Unknown sections must not inherit the preceding parser state
+#Category:InfinityHammer
+#Center:
+#Coordinates:0,0,0
+#Rotation:0,0,0
+#SnapPoints
+#Pieces
+wood_floor;;0;0;0;0;0;0;1;;1;1;1;
+#FuturePieceData:v1
+future_payload;;0;0;0;0;0;0;1;;1;1;1;
+#TerrainHeight:0,0,0;0;1
+1;2
+3;4
+#FutureTerrainData:v1
+999;999
+#TerrainHeight:malformed
+888;888
+#TerrainPaint:0,0,0;0;1
+1:0:0:1;0:1:0:1
+0:0:1:1;1:1:1:1

--- a/tests/fixtures/terrain-rotated-center.blueprint
+++ b/tests/fixtures/terrain-rotated-center.blueprint
@@ -1,0 +1,17 @@
+#Name:Rotated terrain center fixture
+#Creator:Infinity Hammer
+#Description:Recenter this blueprint around the rotated wood_floor
+#Category:InfinityHammer
+#Center:wood_floor
+#Coordinates:0,0,0
+#Rotation:0,0,0
+#SnapPoints
+#Pieces
+wood_floor;;2;1;0;0;0.707;0;0.707;;1;1;1;
+wood_wall;;5;2;4;0;0;0;1;;1;1;1;
+#TerrainHeight:5,7,10;30;1
+11;12
+13;14
+#TerrainPaint:5,7,10;30;1
+1:0:0:1;0:1:0:1
+0:0:1:1;1:1:1:1


### PR DESCRIPTION
## Why

Infinity Hammer can capture terrain with an area selection, but replaying ordered terrain modifier objects is sensitive to creation order and multiplayer timing. This change stores the composed final height and paint values instead, relative to the blueprint root, so a saved area can be reproduced deterministically.

Companion Expand World Data PR: https://github.com/JereKuusela/valheim-expand_world_data/pull/14

## What changed

- Serialize optional #TerrainHeight and #TerrainPaint grids after #Pieces.
- Capture composed Heightmap paint rather than raw TerrainComp defaults.
- Keep terrain anchored to the blueprint root even when the first piece is offset, missing, or the only surviving prefab.
- Reparse a newly saved file before its immediate preview so save-now and reload-later placement use the same data.
- Preserve the terrain transform when a blueprint is recentered or rotated.
- Apply final height values after removing prior smoothing, and write explicit final paint values even when the raw stored color matches.
- Use a selection-root representation independent of object count, including save, placement, add/remove and zoop reset paths.
- Bound compiler lookup, undo and clutter refresh by the actual sample reach plus node spacing; rotated rectangle capture uses the rectangle-aware compiler query.
- Treat unknown or malformed sections as boundaries while retaining metadata/comments in headerless piece lists.
- Reject the earlier #Height/#Paint operation format rather than carrying a legacy replay path.

## Contract

- Header vectors use X,Z,Y ordering and invariant numbers.
- Height samples are relative to the blueprint root Y; paint samples are final RGBA values.
- Empty cells do not modify destination terrain.
- Reference yaw records capture orientation; placement uses its difference from the blueprint root yaw.
- Blueprint object scaling does not scale the terrain grid.

These sections are an Infinity Hammer / Expand World Data extension. Current PlanBuild versions do not recognize the snapshot rows, so a terrain-enabled file is not directly loadable by PlanBuild until it implements the contract.

## Validation

- Debug build: 0 warnings, 0 errors.
- Release build: 0 warnings, 0 errors.
- Shared contract, rotated-center and future-section fixtures.
- Manual fixture matrix documents immediate placement versus reload, multiple yaws, explicit base-biome paint and clear-vegetation paint.
- Companion EWD parser reads the shared fixtures as 2 objects / 3x2 channels, 2 objects / 2x2 channels, and 1 object / 2x2 channels respectively.
- End-to-end local hosted server: a terrain-enabled blueprint was generated as an Expand World Data location and the saved terrain was applied successfully.

Dedicated-server, multi-client, restart/regeneration and remote-owner failure-path coverage remain useful follow-up tests; the local hosted-server result is sufficient to request upstream review.
